### PR TITLE
Make target name more unique

### DIFF
--- a/src/Build/ReferenceProtector.targets
+++ b/src/Build/ReferenceProtector.targets
@@ -4,10 +4,10 @@
   <UsingTask TaskName="CollectAllReferences" AssemblyFile="$(ReferenceProtectorTaskAssembly)" Condition="'$(EnableReferenceProtector)' != 'false'" />
 
   <PropertyGroup>
-    <CoreCompileDependsOn>$(CoreCompileDependsOn);CollectDeclaredReferences</CoreCompileDependsOn>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CollectDeclaredReferencesReferenceProtector</CoreCompileDependsOn>
   </PropertyGroup>
 
-  <Target Name="CollectDeclaredReferences" DependsOnTargets="ResolveAssemblyReferences;PrepareProjectReferences" Condition="'$(EnableReferenceProtector)' != 'false'">
+  <Target Name="CollectDeclaredReferencesReferenceProtector" DependsOnTargets="ResolveAssemblyReferences;PrepareProjectReferences" Condition="'$(EnableReferenceProtector)' != 'false'">
     <PropertyGroup>
       <_ReferenceProtectorDeclaredReferences Condition="$(_ReferenceProtectorDeclaredReferences) == ''">$(IntermediateOutputPath)\references.tsv</_ReferenceProtectorDeclaredReferences>
     </PropertyGroup>

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.1",
-    "assemblyVersion": "1.1",
+    "version": "1.2",
+    "assemblyVersion": "1.2",
     "buildNumberOffset": -1,
     "publicReleaseRefSpec": [
         "^refs/tags/v\\d+\\.\\d+\\.\\d+"


### PR DESCRIPTION
`CollectDeclaredReferences` can collide with the same target from ReferenceTrimmer package. Change the name to dedup