### PR TITLE
Include System.Text.Json dependency in the package

### DIFF
--- a/src/Analyzers/ReferenceProtector.Analyzers/ReferenceProtector.Analyzers.csproj
+++ b/src/Analyzers/ReferenceProtector.Analyzers/ReferenceProtector.Analyzers.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Text.Json" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,6 +18,18 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ReferenceProtector.Analyzers.Tests" />
-  </ItemGroup>  
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <Target Name="_AddAnalyzersToOutput">
+    <Message Importance="High" Text="$(PkgSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" />
+
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(PkgSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" PackagePath="analyzers/dotnet/cs" />
+    </ItemGroup>
+  </Target>  
 
 </Project>

--- a/src/Analyzers/ReferenceProtector.Analyzers/ReferenceProtector.Analyzers.csproj
+++ b/src/Analyzers/ReferenceProtector.Analyzers/ReferenceProtector.Analyzers.csproj
@@ -20,16 +20,14 @@
     <InternalsVisibleTo Include="ReferenceProtector.Analyzers.Tests" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
-  </PropertyGroup>
-
-  <Target Name="_AddAnalyzersToOutput">
-    <Message Importance="High" Text="$(PkgSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" />
-
+  <Target Name="CopyDependenciesToOutput" AfterTargets="Build">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(PkgSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" PackagePath="analyzers/dotnet/cs" />
+      <SystemTextJsonDlls Include="$(PkgSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" />
     </ItemGroup>
-  </Target>  
-
+    <Copy
+      SourceFiles="@(SystemTextJsonDlls)"
+      DestinationFolder="$(OutputPath)"
+      SkipUnchangedFiles="true"
+      Condition="Exists('%(SystemTextJsonDlls.FullPath)')" />
+  </Target>
 </Project>


### PR DESCRIPTION
For some reason from visual studio sometimes we observe AD0001 warning: 
```
Analyzer 'ReferenceProtector.Analyzers.ReferenceProtectorAnalyzer' threw an exception of type 'System.IO.FileNotFoundException' with message 'Could not load file or assembly 'System.Text.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified.'.
```

Even though this works via command line (i.e. `dotnet build`). Researching online - it's possible VS is a bit behind in dependency management of the analyzers (potentially, other IDEs might be too). Some suggest including the dependency in the package in `dotnet/analyzer/cs` folder, that's what's done in this PR