### PR TITLE
Don't update the reference file if no changes were detected

### DIFF
--- a/src/Shared/ReferenceItemExtensions.cs
+++ b/src/Shared/ReferenceItemExtensions.cs
@@ -14,6 +14,18 @@ internal static class ReferenceItemExtensions
 
     public static void SaveToFile(this List<ReferenceItem> items, string outputFile)
     {
+        if (File.Exists(outputFile))
+        {
+            var currentContents = File.ReadAllLines(outputFile);
+            var newContents = items.Select(item => item.ToFileLine()).ToArray();
+            // Assuming order is the same for incremental builds, no sorting needed
+            if (currentContents.SequenceEqual(newContents))
+            {
+                // No changes, skip writing to avoid updating the timestamp, which will trigger unnecessary rebuilds
+                return;
+            }
+        }
+
         File.WriteAllLines(outputFile, items.Select(item => item.ToFileLine()));
     }
 

--- a/src/Tasks/ReferenceProtector.Tasks.IntegrationTests/ReferenceProtector.Tasks.TestBase.cs
+++ b/src/Tasks/ReferenceProtector.Tasks.IntegrationTests/ReferenceProtector.Tasks.TestBase.cs
@@ -143,7 +143,7 @@ public class Class1
     {
         string buildArgs =
             $"build dirs.proj " +
-            $"-m:1 -t:Rebuild -restore -nologo -nodeReuse:false -noAutoResponse " +
+            $"-m:1 -restore -nologo -nodeReuse:false -noAutoResponse " +
             $"/p:Configuration=Debug " +
             $"/p:ReferenceProtectorTaskAssembly={Path.Combine(Directory.GetCurrentDirectory(), "ReferenceProtector.Tasks.dll")} " +
             $"/v:m" +

--- a/src/Tasks/ReferenceProtector.Tasks.IntegrationTests/ReferenceProtector.Tasks.Tests.cs
+++ b/src/Tasks/ReferenceProtector.Tasks.IntegrationTests/ReferenceProtector.Tasks.Tests.cs
@@ -127,6 +127,9 @@ public class CollectAllReferencesIntegrationTests : TestBase
         Assert.Equal(expectedReferences, references);
     }
 
+    /// <summary>
+    /// Verifies that the CollectAllReferences task does not update the reference file timestamp if no changes were made.
+    /// </summary>
     [Fact]
     public async Task CollectAllReferences_IncrememtalBuild_ReferenceTimestampIsNotUpdated()
     {
@@ -135,14 +138,16 @@ public class CollectAllReferencesIntegrationTests : TestBase
         await AddProjectReference("A", "B");
         await Build();
 
-        var generatedFiles = GetGeneratedReferencesFiles();
-
-        var timeStamps1 = generatedFiles.Select(File.GetLastWriteTimeUtc).ToList();
+        var generatedFiles1 = GetGeneratedReferencesFiles();
+        var timeStamps1 = generatedFiles1.Select(File.GetLastWriteTimeUtc).ToList();
 
         // Rebuild without any changes
         await Build();
 
-        var timeStamps2 = generatedFiles.Select(File.GetLastWriteTimeUtc).ToList();
+        var generatedFiles2 = GetGeneratedReferencesFiles();
+        var timeStamps2 = generatedFiles2.Select(File.GetLastWriteTimeUtc).ToList();
+
+        Assert.Equal(generatedFiles1, generatedFiles2);
         Assert.Equal(timeStamps1, timeStamps2);
     }
 }

--- a/src/Tasks/ReferenceProtector.Tasks.IntegrationTests/ReferenceProtector.Tasks.Tests.cs
+++ b/src/Tasks/ReferenceProtector.Tasks.IntegrationTests/ReferenceProtector.Tasks.Tests.cs
@@ -126,4 +126,23 @@ public class CollectAllReferencesIntegrationTests : TestBase
 
         Assert.Equal(expectedReferences, references);
     }
+
+    [Fact]
+    public async Task CollectAllReferences_IncrememtalBuild_ReferenceTimestampIsNotUpdated()
+    {
+        CreateProject("A");
+        CreateProject("B");
+        await AddProjectReference("A", "B");
+        await Build();
+
+        var generatedFiles = GetGeneratedReferencesFiles();
+
+        var timeStamps1 = generatedFiles.Select(File.GetLastWriteTimeUtc).ToList();
+
+        // Rebuild without any changes
+        await Build();
+
+        var timeStamps2 = generatedFiles.Select(File.GetLastWriteTimeUtc).ToList();
+        Assert.Equal(timeStamps1, timeStamps2);
+    }
 }

--- a/src/Tasks/ReferenceProtector.Tasks/CollectAllReferences.cs
+++ b/src/Tasks/ReferenceProtector.Tasks/CollectAllReferences.cs
@@ -82,7 +82,9 @@ public class CollectAllReferences : Microsoft.Build.Utilities.Task
 
         if (OutputFile is not null)
         {
-            references.SaveToFile(OutputFile);
+            // Is sorted to ensure consistent ordering for easier testing and to avoid unnecessary diffs
+            // May not needed, if msbuild guarantees a consistent order
+            references.OrderBy(x => (x.Source, x.Target, x.LinkType)).ToList().SaveToFile(OutputFile);
             return true;
         }
 


### PR DESCRIPTION
During incremental builds - msbuild task that collects and dumps references into a file always does so, even if no actual content had changed.
Instead - read from the file first (if it's there) and compare the content. Skip writing to the file if contents are the same. Otherwise this will be considered a `new file` and msbuild will not skip rebuilding