### PR TITLE
Normalize pattern matching

### DIFF
--- a/src/Analyzers/ReferenceProtector.Analyzers/ReferenceProtector.Analyzers.cs
+++ b/src/Analyzers/ReferenceProtector.Analyzers/ReferenceProtector.Analyzers.cs
@@ -337,10 +337,12 @@ public class ReferenceProtectorAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool IsMatchByName(string pattern, string project)
+    private static bool IsMatchByName(string pattern, string value)
     {
+        pattern = pattern.Replace('\\', '/');
+        value = value.Replace('\\', '/');
         var regex = Regex.Escape(pattern).Replace("\\*", ".*") + "$";
-        var match = Regex.IsMatch(project, regex, RegexOptions.IgnoreCase);
+        var match = Regex.IsMatch(value, regex, RegexOptions.IgnoreCase);
         return match;
     }    
 }


### PR DESCRIPTION
This pull request updates the `IsMatchByName` method to improve its handling of path separators and clarify parameter naming. The changes ensure that both the pattern and the value being matched use consistent path separators, which helps prevent mismatches on different operating systems.

Improvements to pattern matching:

* Updated the `IsMatchByName` method to normalize path separators by replacing backslashes with forward slashes in both the `pattern` and `value` parameters, improving cross-platform matching.
* Renamed the `project` parameter to `value` in `IsMatchByName` for better clarity and generality.