### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/olstakh/ReferenceProtector/security/code-scanning/1](https://github.com/olstakh/ReferenceProtector/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/pr.yml` so the workflow does not rely on inherited defaults.

Best fix (without changing behavior): define workflow-level permissions right after the `on:` trigger section and before `jobs:`:

- `contents: read` (required baseline for checkout and repository reads)

This applies to all jobs in the workflow (currently just `build`) and preserves existing functionality while enforcing least privilege. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
